### PR TITLE
Task Native.WebSocket.close always succeeds with Maybe BadClose

### DIFF
--- a/src/Native/WebSocket.js
+++ b/src/Native/WebSocket.js
@@ -73,12 +73,11 @@ function close(code, reason, socket)
 		}
 		catch(err)
 		{
-			return callback(_elm_lang$core$Native_Scheduler.fail({
-				ctor: err instanceof SyntaxError ? 'BadReason' : 'BadCode',
-				_0: err.message
-			}));
+			return callback(_elm_lang$core$Native_Scheduler.succeed(
+        _elm_lang$core$Maybe$Just({ ctor: err instanceof SyntaxError ? 'BadReason' : 'BadCode' })
+      ));
 		}
-		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Native_Utils.Tuple0));
+		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Maybe$Nothing));
 	});
 }
 


### PR DESCRIPTION
The type is annotated as

``` elm
closeWith : Int -> String -> WebSocket -> Task x (Maybe BadClose)
closeWith = Native.WebSocket.close
```

But the native code was written as if the type would have been:

``` elm
closeWith : Int -> String -> WebSocket -> Task BadClose ()
closeWith = Native.WebSocket.close
```
