### PR TITLE
Use err.name to classify exception

### DIFF
--- a/src/Native/WebSocket.js
+++ b/src/Native/WebSocket.js
@@ -11,7 +11,7 @@ function open(url, settings)
 		catch(err)
 		{
 			return callback(_elm_lang$core$Native_Scheduler.fail({
-				ctor: err instanceof SecurityError ? 'BadSecurity' : 'BadArgs',
+				ctor: err.name == 'SecurityError' ? 'BadSecurity' : 'BadArgs',
 				_0: err.message
 			}));
 		}
@@ -74,7 +74,7 @@ function close(code, reason, socket)
 		catch(err)
 		{
 			return callback(_elm_lang$core$Native_Scheduler.fail({
-				ctor: err instanceof SyntaxError ? 'BadReason' : 'BadCode',
+				ctor: err.name == 'SyntaxError' ? 'BadReason' : 'BadCode',
 				_0: err.message
 			}));
 		}


### PR DESCRIPTION
Use err.name to classify exception

This throws `Uncaught ReferenceError: SecurityError is not defined`:

``` js
catch(err){ // ...
            err instanceof SecurityError ? 'BadSecurity' : 'BadArgs', // ...
        }
```

Testing the string err.name to equal a string literal works:

``` js
catch(err){ // ...
            err.name == 'SecurityError' ? 'BadSecurity' : 'BadArgs', // ...
        }
```
