### PR TITLE
Inherit protocol and endpoint when not specified.

### DIFF
--- a/src/Native/WebSocket.js
+++ b/src/Native/WebSocket.js
@@ -16,7 +16,7 @@ function open(url, settings)
 	{
 		try
 		{
-      var socket = new WebSocket(getEndpointURL(url));
+			var socket = new WebSocket(getEndpointURL(url));
 			socket.elm_web_socket = true;
 		}
 		catch(err)

--- a/src/Native/WebSocket.js
+++ b/src/Native/WebSocket.js
@@ -1,12 +1,22 @@
 var _elm_lang$websocket$Native_WebSocket = function() {
 
+function getProtocol(){ return location.protocol.match(/^https/) ? "wss" : "ws" }
+
+function getEndpointURL(uri)
+{
+  if(uri.charAt(0) !== "/"){ return uri; }
+  if(uri.charAt(1) === "/"){ return getProtocol() + ':' + uri; }
+
+  return getProtocol() + '://' + location.host + uri;
+}
+
 function open(url, settings)
 {
 	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 	{
 		try
 		{
-			var socket = new WebSocket(url);
+      var socket = new WebSocket(getEndpointURL(url));
 			socket.elm_web_socket = true;
 		}
 		catch(err)


### PR DESCRIPTION
This makes it easy to have the same code running in dev/staging/production environments since you are now able to use relative paths instead of absolute paths for the websocket endpoint.

Addresses https://github.com/fbonetti/elm-phoenix-socket/issues/6
