### PR TITLE
Websocket 1.1.0 proposal

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "2.0.0",
     "summary": "Persistent network connections, making client/server communication faster.",
     "repository": "http://github.com/elm-lang/websocket.git",
     "license": "BSD3",

--- a/src/WebSocket.elm
+++ b/src/WebSocket.elm
@@ -1,8 +1,10 @@
 effect module WebSocket where { command = MyCmd, subscription = MySub } exposing
   ( send
   , listen
+  , connect
   , onOpen
   , onClose
+  , Error(..)
   )
 
 {-| Web sockets make it cheaper to talk to your servers.
@@ -21,7 +23,7 @@ The API here attempts to cover the typical usage scenarios, but if you need
 many unique connections to the same endpoint, you need a different library.
 
 # Web Sockets
-@docs listen, onOpen, onClose, send
+@docs connect, listen, send, onOpen, onClose, Error
 
 -}
 
@@ -37,6 +39,19 @@ import WebSocket.LowLevel as WS
 
 type MyCmd msg
   = Send String String
+  | Connect String
+
+
+-- ERRORS
+
+
+{-| The `connect` and `send` functions may fail for a variety of reasons.
+In each case, the browser will provide a string with additional information.
+-}
+type Error
+    = ConnectFailed
+    | SendFailed
+
 
 
 {-| Send a message to a particular address. You might say something like this:
@@ -52,10 +67,26 @@ send url message =
   command (Send url message)
 
 
-cmdMap : (a -> b) -> MyCmd a -> MyCmd b
-cmdMap _ (Send url msg) =
-  Send url msg
+{-| Attempt to connect to a particular address. You might say something like this:
 
+    connect "ws://echo.websocket.org"
+
+**Note:** It is important that you are also subscribed to this address with
+`listen` if you want to handle messages from the connection!
+-}
+connect : String -> Cmd msg
+connect url =
+  command (Connect url)
+
+
+cmdMap : (a -> b) -> MyCmd a -> MyCmd b
+cmdMap _ cmd =
+  case cmd of
+    Send url msg ->
+      Send url msg
+
+    Connect url ->
+      Connect url
 
 
 -- SUBSCRIPTIONS
@@ -73,8 +104,6 @@ like this:
     subscriptions model =
       listen "ws://echo.websocket.org" Echo
 
-**Note:** If the connection goes down, the effect manager tries to reconnect
-with an exponential backoff strategy.
 -}
 listen : String -> (String -> msg) -> Sub msg
 listen url tagger =
@@ -133,7 +162,7 @@ type alias SubsDict msg =
 
 
 type Connection
-  = Opening Int Process.Id
+  = Opening Process.Id
   | Connected WS.WebSocket
 
 
@@ -164,22 +193,45 @@ onEffects router cmds subs state =
     newEntries =
       buildEntriesDict subs Dict.empty
 
-    leftStep category _ getNewSockets =
+    leftStep name _ getNewSockets =
       getNewSockets
-        |> Task.andThen (\newSockets -> attemptOpen router 0 category
-        |> Task.andThen (\pid -> Task.succeed (Dict.insert category (Opening 0 pid) newSockets)))
 
-    bothStep category _ connection getNewSockets =
-      Task.map (Dict.insert category connection) getNewSockets
+    bothStep name _ connection getNewSockets =
+      Task.map (Dict.insert name connection) getNewSockets
 
-    rightStep category connection getNewSockets =
+    rightStep name connection getNewSockets =
       closeConnection connection &> getNewSockets
-
-    collectNewSockets =
-      Dict.merge leftStep bothStep rightStep newEntries state.sockets (Task.succeed Dict.empty)
   in
-    collectNewSockets
+    Dict.merge leftStep bothStep rightStep newEntries state.sockets (Task.succeed Dict.empty)
+      |> Task.andThen (\newSockets -> cmdHelp router cmds newSockets)
       |> Task.andThen (\newSockets -> Task.succeed (State newSockets newSubs))
+
+
+cmdHelp : Platform.Router msg Msg -> List (MyCmd msg) -> SocketsDict -> Task Never SocketsDict
+cmdHelp router cmds socketsDict =
+  case cmds of
+    [] ->
+      Task.succeed socketsDict
+
+    Send name msg :: rest ->
+      case Dict.get name socketsDict of
+        Just (Connected socket) ->
+          WS.send socket msg
+            &> cmdHelp router rest socketsDict
+
+        _ ->
+          Task.succeed socketsDict
+          --Task.fail SendFailed -- Not connected
+
+    Connect name :: rest ->
+      case Dict.get name socketsDict of
+        Just (Connected _) ->
+          Task.succeed socketsDict
+          --Task.fail ConnectFailed -- already connected
+
+        _ ->
+            attemptOpen router name
+            |> Task.andThen (\pid -> Task.succeed (Dict.insert name (Opening pid) socketsDict))
 
 
 
@@ -225,8 +277,7 @@ set value maybeDict =
 type Msg
   = Receive String String
   | Die String
-  | GoodOpen String WS.WebSocket
-  | BadOpen String
+  | Open String WS.WebSocket
 
 
 onSelfMsg : Platform.Router msg Msg -> Msg -> State msg -> Task Never (State msg)
@@ -247,19 +298,23 @@ onSelfMsg router selfMsg state =
         Nothing ->
           Task.succeed state
 
-        Just _ ->
+        Just conn ->
           let
             sends =
-              Dict.get "onClose" state.subs
-                |> Maybe.withDefault Dict.empty
-                |> Dict.toList
-                |> List.map (\(_, tagger) -> Platform.sendToApp router (tagger name))
-          in
-            Task.sequence sends
-              |> Task.andThen (\_ -> attemptOpen router 0 name)
-              |> Task.andThen (\pid -> Task.succeed (updateSocket name (Opening 0 pid) state))
+              case conn of
+                Connected _ ->
+                  Dict.get "onClose" state.subs
+                    |> Maybe.withDefault Dict.empty
+                    |> Dict.toList
+                    |> List.map (\(_, tagger) -> Platform.sendToApp router (tagger name))
 
-    GoodOpen name socket ->
+                Opening _ -> -- Don't report close events if we never actually connected
+                    []
+          in
+            Task.sequence sends &> Task.succeed state
+              |> Task.andThen (\_ -> Task.succeed (removeSocket name state))
+
+    Open name socket ->
       let
         sends =
           Dict.get "onOpen" state.subs
@@ -268,18 +323,12 @@ onSelfMsg router selfMsg state =
             |> List.map (\(_, tagger) -> Platform.sendToApp router (tagger name))
       in
         Task.sequence sends &> Task.succeed state
+            |> Task.andThen (\_ -> Task.succeed (updateSocket name (Connected socket) state))
 
-    BadOpen name ->
-      case Dict.get name state.sockets of
-        Nothing ->
-          Task.succeed state
 
-        Just (Opening n _) ->
-          attemptOpen router (n + 1) name
-            |> Task.andThen (\pid -> Task.succeed (updateSocket name (Opening (n + 1) pid) state))
-
-        Just (Connected _) ->
-          Task.succeed state
+removeSocket : String -> State msg -> State msg
+removeSocket name state =
+  { state | sockets = Dict.remove name state.sockets }
 
 
 updateSocket : String -> Connection -> State msg -> State msg
@@ -287,25 +336,21 @@ updateSocket name connection state =
   { state | sockets = Dict.insert name connection state.sockets }
 
 
-
--- OPENING WEBSOCKETS WITH EXPONENTIAL BACKOFF
-
-
-attemptOpen : Platform.Router msg Msg -> Int -> String -> Task x Process.Id
-attemptOpen router backoff name =
+attemptOpen : Platform.Router msg Msg -> String -> Task x Process.Id
+attemptOpen router name =
   let
     goodOpen ws =
-      Platform.sendToSelf router (GoodOpen name ws)
+      Platform.sendToSelf router (Open name ws)
 
     badOpen _ =
-      Platform.sendToSelf router (BadOpen name)
+      Platform.sendToSelf router (Die name)
 
     actuallyAttemptOpen =
       open name router
         |> Task.andThen goodOpen
         |> Task.onError badOpen
   in
-    Process.spawn (after backoff &> actuallyAttemptOpen)
+    Process.spawn actuallyAttemptOpen
 
 
 open : String -> Platform.Router msg Msg -> Task WS.BadOpen WS.WebSocket
@@ -316,15 +361,6 @@ open name router =
     }
 
 
-after : Int -> Task x ()
-after backoff =
-  if backoff < 1 then
-    Task.succeed ()
-
-  else
-    Process.sleep (toFloat (10 * 2 ^ backoff))
-
-
 
 -- CLOSE CONNECTIONS
 
@@ -332,7 +368,7 @@ after backoff =
 closeConnection : Connection -> Task x ()
 closeConnection connection =
   case connection of
-    Opening _ pid ->
+    Opening pid ->
       Process.kill pid
 
     Connected socket ->

--- a/src/WebSocket.elm
+++ b/src/WebSocket.elm
@@ -42,8 +42,8 @@ type MyCmd msg
     send "ws://echo.websocket.org" "Hello!"
 
 **Note:** It is important that you are also subscribed to this address with
-`listen` or `keepAlive`. If you are not, the web socket will be created to
-send one message and then closed. Not good!
+`listen`. If you are not, the web socket will be created to send one message
+and then closed. Not good!
 -}
 send : String -> String -> Cmd msg
 send url message =
@@ -72,8 +72,7 @@ like this:
       listen "ws://echo.websocket.org" Echo
 
 **Note:** If the connection goes down, the effect manager tries to reconnect
-with an exponential backoff strategy. Any messages you try to `send` while the
-connection is down are queued and will be sent as soon as possible.
+with an exponential backoff strategy.
 -}
 listen : String -> (String -> msg) -> Sub msg
 listen url tagger =


### PR DESCRIPTION
### Proposed changes

**Add `onOpen` and `onClose` subscriptions**

This would fix #14 and #10 and was my primary motivation for proposing these changes. These subscriptions are important for pretty much any non-trivial scenario, and appears to be the most requested feature for the websocket package.

**Reset backoff when page becomes visible**

With exponential backoff fixed, reconnect attempts occur far less frequently than when it was broken. It makes sense to reset the backoff when the page becomes visible, otherwise, the user would have to refresh the page if they want the application to reconnect immediately.

### Feedback

This pull request is the result of my hacking over the weekend and there are probably issues or things that need to be cleaned up. I also removed `keepAlive` temporarily just to make it easier to hack in the proposed changes. I'm interested in hearing feedback for the proposed changes, and if/when something concrete is decided, I will clean up this PR.
